### PR TITLE
#4 - Simplifying feature template and adding devops template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/devops.md
+++ b/.github/ISSUE_TEMPLATE/devops.md
@@ -1,0 +1,20 @@
+---
+name: DevOps
+about: Suggest improvements to the tooling and automation, such as automated testing, publishing and documentaiton.
+title: "[DevOps]: "
+labels: devops
+assignees: masiw
+
+---
+
+**Is your enhancement request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. The code is hard to maintain because [...]
+
+**Describe the improvement you'd like**
+A clear and concise description of the improvement or refactoring you want to see.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative approaches or solutions you've considered.
+
+**Additional context**
+Add any other context or screenshots about the enhancement request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,31 +1,20 @@
 ---
 name: Feature Request
-about: In order to add new functionality to the project. The can be adding new feature
-  to the end product, new tesing capilities, or new devops functionality,
+about: In order to add new functionality to the product.
 title: "[Feature]: "
 labels: ''
 assignees: ''
 
 ---
 
-| Question | Answer |
+| Story |  |
 | ---- | ---- |
 | As a |  |
 | I want to |  |
 | so that |  |
 
-
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
 
 **Definition of done**
 Add any features required. Below is a checklist to help define when the feature is complete:
@@ -33,5 +22,4 @@ Add any features required. Below is a checklist to help define when the feature 
 - [ ] Code implementation is complete
 - [ ] Unit tests are written and passing
 - [ ] Documentation is updated
-- [ ] Code is reviewed and approved
 - [ ] Feature is tested in staging/production environment


### PR DESCRIPTION
I simplified the feature request template and restricted it to features of the product itself. So any non-functional requirements or anything that does not add/remove/change behaviour from the published product does not belong here.

For non-functional requirements, like ci/cd tooling and automation, I added the devops template.